### PR TITLE
支持不提交消息 & kafka 错误时，不退出 consumer server

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -7,6 +7,8 @@ import (
 	"github.com/gotomicro/ego/core/etrace"
 	"github.com/gotomicro/ego/core/transport"
 	"github.com/segmentio/kafka-go"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
 )
 
 // Consumer 消费者/消费者组，
@@ -159,5 +161,11 @@ func (r *Consumer) getCtx(ctx context.Context, msg Message) context.Context {
 			}
 		}
 	}
-	return ctx
+	// 注入 trace 信息
+	carrier := propagation.MapCarrier{}
+	// 首先看header头里，也就是从producer里传递的trace id
+	for _, value := range msg.Headers {
+		carrier[value.Key] = string(value.Value)
+	}
+	return otel.GetTextMapPropagator().Extract(ctx, carrier)
 }


### PR DESCRIPTION
1. 去除消费错误的channel
2. handler 返回错误认为是不提交message
3. kafka 非重试错误时，重建消费者实例