### PR TITLE
kafka compress

### DIFF
--- a/compress.go
+++ b/compress.go
@@ -1,0 +1,76 @@
+package ekafka
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"sync"
+)
+
+var (
+	compressorsMu     sync.RWMutex
+	compressors       = make(map[string]Compressor)
+	defaultCompressor = &gzipCompressor{}
+)
+
+const (
+	compressTypeGzip = "gzip"
+	// 10K
+	defaultCompressLimit = 1024_0
+)
+
+type Compressor interface {
+	Compress(input []byte) (output []byte, err error)
+	DeCompress(input []byte) (output []byte, err error)
+	ContentEncoding() string
+}
+
+func Register(comp Compressor) {
+	compressorsMu.Lock()
+	defer compressorsMu.Unlock()
+	compressors[comp.ContentEncoding()] = comp
+}
+
+func GetCompressor(encoding string) Compressor {
+	if encoding == "" {
+		return defaultCompressor
+	}
+	compressorsMu.RLock()
+	defer compressorsMu.RUnlock()
+	return compressors[encoding]
+}
+
+type gzipCompressor struct {
+}
+
+func (g *gzipCompressor) Compress(input []byte) (output []byte, err error) {
+	var compressedBuffer bytes.Buffer
+	gw := gzip.NewWriter(&compressedBuffer)
+	_, err = gw.Write(input)
+	if err != nil {
+		_ = gw.Close()
+		return nil, err
+	}
+	if err = gw.Close(); err != nil {
+		return nil, err
+	}
+	return compressedBuffer.Bytes(), nil
+}
+
+func (g *gzipCompressor) DeCompress(input []byte) (output []byte, err error) {
+	reader, err := gzip.NewReader(bytes.NewReader(input))
+	if err != nil {
+		return nil, err
+	}
+	defer reader.Close()
+	var deCompressedBuffer bytes.Buffer
+	_, err = io.Copy(&deCompressedBuffer, reader)
+	if err != nil {
+		return nil, err
+	}
+	return deCompressedBuffer.Bytes(), nil
+}
+
+func (g *gzipCompressor) ContentEncoding() string {
+	return compressTypeGzip
+}

--- a/compress.go
+++ b/compress.go
@@ -31,6 +31,10 @@ func Register(comp Compressor) {
 	compressors[comp.ContentEncoding()] = comp
 }
 
+func init() {
+	Register(defaultCompressor)
+}
+
 func GetCompressor(encoding string) Compressor {
 	if encoding == "" {
 		return defaultCompressor

--- a/compress_test.go
+++ b/compress_test.go
@@ -1,0 +1,22 @@
+package ekafka
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+var (
+	testData = `Hello 你好😂`
+)
+
+func TestGzipCompressor_Compress(t *testing.T) {
+	output, err := defaultCompressor.Compress([]byte(testData))
+	if err != nil {
+		panic(err)
+	}
+	deCompress, err := defaultCompressor.DeCompress(output)
+	if err != nil {
+		panic(err)
+	}
+	assert.Equal(t, testData, string(deCompress))
+}

--- a/config.go
+++ b/config.go
@@ -25,11 +25,14 @@ type config struct {
 	clientInterceptors         []ClientInterceptor
 	serverInterceptors         []ServerInterceptor
 	balancers                  map[string]Balancer
-	EnableTraceInterceptor     bool // 是否开启链路追踪，默认开启
-	EnableAccessInterceptor    bool // 是否开启记录请求数据，默认不开启
-	EnableAccessInterceptorReq bool // 是否开启记录请求参数，默认不开启
-	EnableAccessInterceptorRes bool // 是否开启记录响应参数，默认不开启
-	EnableMetricInterceptor    bool // 是否开启监控，默认开启
+	EnableTraceInterceptor     bool   // 是否开启链路追踪，默认开启
+	EnableAccessInterceptor    bool   // 是否开启记录请求数据，默认不开启
+	EnableAccessInterceptorReq bool   // 是否开启记录请求参数，默认不开启
+	EnableAccessInterceptorRes bool   // 是否开启记录响应参数，默认不开启
+	EnableMetricInterceptor    bool   // 是否开启监控，默认开启
+	EnableCompress             bool   // 是否开启压缩，默认不开启
+	CompressLimit              int    // 大于该值后才压缩，单位字节
+	CompressType               string // 压缩算法，默认gzip
 	// TLS 参数支持
 	Authentication Authentication
 }
@@ -129,6 +132,7 @@ type consumerGroupConfig struct {
 const (
 	balancerHash       = "hash"
 	balancerRoundRobin = "roundRobin"
+	compressHeaderKey  = "Content-Encoding"
 )
 
 // DefaultConfig 返回默认配置

--- a/consumer.go
+++ b/consumer.go
@@ -108,7 +108,7 @@ func (r *Consumer) FetchMessage(ctx context.Context) (msg Message, ctxOutput con
 		msg, err = r.r.FetchMessage(ctx)
 		// 在后面才解析了header
 		ctxOutput = r.getCtx(ctx, msg)
-		logCmd(r.logMode, c, "FetchMessage", cmdWithMsg(msg))
+		logCmd(r.logMode, c, "FetchMessage", cmdWithMsg(msg), cmdWithRes(&msg))
 		return err
 	})(ctx, nil, &cmd{})
 	return
@@ -136,7 +136,7 @@ func (r *Consumer) ReadMessage(ctx context.Context) (msg Message, ctxOutput cont
 		msg, err = r.r.ReadMessage(ctx)
 		// 在后面才解析了header
 		ctxOutput = r.getCtx(ctx, msg)
-		logCmd(r.logMode, c, "ReadMessage", cmdWithRes(msg), cmdWithMsg(msg))
+		logCmd(r.logMode, c, "ReadMessage", cmdWithRes(&msg), cmdWithMsg(msg))
 		return err
 	})(ctx, nil, &cmd{})
 	return

--- a/container.go
+++ b/container.go
@@ -53,6 +53,17 @@ func (c *Container) Build(options ...Option) *Component {
 		options = append(options, WithServerInterceptor(metricServerInterceptor(c.name, c.config)))
 	}
 
+	if c.config.EnableCompress {
+		if c.config.CompressLimit <= 0 {
+			c.config.CompressLimit = defaultCompressLimit
+		}
+		// 注册默认压缩器
+		//Register(defaultCompressor)
+		// 加载 interceptor
+		options = append(options, WithClientInterceptor(compressClientInterceptor(c.name, c.config, c.logger)),
+			WithServerInterceptor(compressServerInterceptor(c.name, c.config, c.logger)))
+	}
+
 	for _, option := range options {
 		option(c)
 	}

--- a/examples/compressinterceptor/config.toml
+++ b/examples/compressinterceptor/config.toml
@@ -1,0 +1,16 @@
+[kafka]
+debug = true
+EnableAccessInterceptor = true
+EnableAccessInterceptorReq = true
+EnableAccessInterceptorRes = true
+EnableCompress = true
+# 50B
+CompressLimit = 50
+brokers = ["192.168.64.65:9091", "192.168.64.65:9092", "192.168.64.65:9093"]
+[kafka.client]
+timeout = "3s"
+[kafka.producers.p1]        # 定义了名字为p1的producer
+topic = "sre-infra-debug"  # 指定生产消息的topic
+[kafka.consumers.c1]        # 定义了名字为c1的consumer
+topic = "sre-infra-debug"  # 指定消费的topic
+groupID = "group-0"       # 如果配置了groupID，将初始化为consumerGroup

--- a/examples/compressinterceptor/main.go
+++ b/examples/compressinterceptor/main.go
@@ -13,10 +13,11 @@ func main() {
 		//初始化ekafka组件
 		cmp := ekafka.Load("kafka").Build()
 		// 使用p1生产者生产消息
-		produce(context.Background(), cmp.Producer("p1"))
+		ctx := context.Background()
+		produce(ctx, cmp.Producer("p1"))
 
 		// 使用c1消费者消费消息
-		consume(cmp.Consumer("c1"))
+		consume(ctx, cmp.Consumer("c1"))
 		return nil
 	}).Run()
 
@@ -44,12 +45,7 @@ func produce(ctx context.Context, w *ekafka.Producer) {
 }
 
 // consume 使用consumer/consumerGroup消费消息
-func consume(r *ekafka.Consumer) {
-	ctx := context.Background()
-	err := r.SetOffset(32)
-	if err != nil {
-		panic(err)
-	}
+func consume(ctx context.Context, r *ekafka.Consumer) {
 	for {
 		// ReadMessage 再收到下一个Message时，会阻塞
 		msg, ctxOutput, err := r.FetchMessage(ctx)

--- a/examples/compressinterceptor/main.go
+++ b/examples/compressinterceptor/main.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/ego-component/ekafka"
+	"github.com/gotomicro/ego"
+	"log"
+)
+
+func main() {
+	ego.New().Invoker(func() error {
+		//初始化ekafka组件
+		cmp := ekafka.Load("kafka").Build()
+		// 使用p1生产者生产消息
+		produce(context.Background(), cmp.Producer("p1"))
+
+		// 使用c1消费者消费消息
+		consume(cmp.Consumer("c1"))
+		return nil
+	}).Run()
+
+}
+
+func produce(ctx context.Context, w *ekafka.Producer) {
+	err := w.WriteMessages(ctx, &ekafka.Message{
+		Key:   []byte("Key-compress"),
+		Value: []byte("Hello World!Hello World!Hello World!Hello World!Hello World!Hello World!Hello World!Hello World!Hello World!Hello World!Hello World!Hello World!Hello World!Hello World!Hello World!Hello World!"),
+	})
+	if err != nil {
+		log.Fatal("failed to write messages:", err)
+	}
+
+	err = w.WriteMessages(ctx, &ekafka.Message{
+		Key:   []byte("Key-no-compress"),
+		Value: []byte("Hello World!"),
+	})
+	if err != nil {
+		log.Fatal("failed to write messages:", err)
+	}
+	if err = w.Close(); err != nil {
+		log.Fatal("failed to close writer:", err)
+	}
+}
+
+// consume 使用consumer/consumerGroup消费消息
+func consume(r *ekafka.Consumer) {
+	ctx := context.Background()
+	err := r.SetOffset(32)
+	if err != nil {
+		panic(err)
+	}
+	for {
+		// ReadMessage 再收到下一个Message时，会阻塞
+		msg, ctxOutput, err := r.FetchMessage(ctx)
+		if err != nil {
+			panic("could not read message " + err.Error())
+		}
+		// 打印消息
+		fmt.Println("received headers: ", msg.Headers)
+		fmt.Println("received: ", string(msg.Value))
+		err = r.CommitMessages(ctxOutput, &msg)
+		if err != nil {
+			log.Printf("fail to commit msg:%v", err)
+		}
+	}
+}


### PR DESCRIPTION
- `EnableCompress` 是否开启压缩
- `CompressLimit`  触发压缩大小阈值 默认10KB
- `CompressType` 默认 gzip 用户可以调用Register方法注册自定义压缩方式
- 写入时使用 compressClientInterceptor，header中增加 `Content-Encoding`
- 读取时候使用 compressServerInterceptor，解压之后移除header中的 `Content-Encoding`